### PR TITLE
Adjust value of STATE_ACTIVATE to conform to OpenPGP card spec

### DIFF
--- a/src/gpg_types.h
+++ b/src/gpg_types.h
@@ -300,7 +300,7 @@ typedef struct gpg_v_state_s gpg_v_state_t;
 #define ID_DEC 2
 #define ID_SIG 3
 
-#define STATE_ACTIVATE 0x07
+#define STATE_ACTIVATE 0x05
 #define STATE_TERMINATE 0x03
 
 #define IO_OFFSET_END (unsigned int)-1


### PR DESCRIPTION
Based on the OpenPGP card spec, I think this value should be 5.
(However, GnuPG as far as I understand doesn't do much with this status value)

Context: I'm working on a new OpenPGP card client library https://crates.io/crates/openpgp-card and am trying to avoid adding card-specific workaround code.

(FYI: I hope send more small MRs soon, as I work my way through my test suite with the Ledger)